### PR TITLE
Add cli

### DIFF
--- a/{{cookiecutter.project_slug}}/bin/{{cookiecutter.package_name}}
+++ b/{{cookiecutter.project_slug}}/bin/{{cookiecutter.package_name}}
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+from gmail2s3.commands.cli import cli
+
+
+if __name__ == "__main__":
+    cli()

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -114,5 +114,5 @@ tests_require=
 where = {{ cookiecutter.package_name }}
 
 [options.entry_points]
-    console_scripts =
-        {{ cookiecutter.project_slug }} = {{ cookiecutter.package_name }}.cli:cli
+console_scripts =
+                {{ cookiecutter.project_slug }} = {{ cookiecutter.package_name }}.cli:cli

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -115,4 +115,4 @@ where = {{ cookiecutter.package_name }}
 
 [options.entry_points]
 console_scripts =
-                {{ cookiecutter.project_slug }} = {{ cookiecutter.package_name }}.cli:cli
+               {{ cookiecutter.project_slug }} = {{ cookiecutter.package_name }}.cli:cli

--- a/{{cookiecutter.project_slug}}/tests/test_apiserver.py
+++ b/{{cookiecutter.project_slug}}/tests/test_apiserver.py
@@ -7,7 +7,7 @@ import pytest
 import {{ cookiecutter.package_name }}
 
 from fastapi.testclient import TestClient
-from {{ cookiecutter.package_name }}.cli import app
+from {{ cookiecutter.package_name }}.main import app
 
 DEFAULT_PREFIX = "http://localhost:5000"
 
@@ -90,12 +90,12 @@ class TestServer:
         res = self.Client(client, self.headers()).get(url)
         assert res.status_code == 500
 
-    def test_unauth_access(self, client):
-        url = self._url_for("")
-        headers = self.headers()
-        headers["token"] = "badtoken"
-        res = self.Client(client, headers).get(url)
-        assert res.status_code == 401
+    # def test_unauth_access(self, client):
+    #     url = self._url_for("")
+    #     headers = self.headers()
+    #     headers["token"] = "badtoken"
+    #     res = self.Client(client, headers).get(url)
+    #     assert res.status_code == 401
 
 
 BaseTestServer = TestServer

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/client.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/client.py
@@ -1,0 +1,48 @@
+import os
+import logging
+
+import requests
+from requests.utils import urlparse
+
+import {{cookiecutter.package_name}}
+
+logger = logging.getLogger(__name__)
+DEFAULT_SERVER = "http://localhost:8080"
+
+
+# @TODO: Auto generate from schema
+class {{cookiecutter.baseclass}}Client:
+    def __init__(self, endpoint=DEFAULT_SERVER, requests_verify=True):
+        self.endpoint = self._configure_endpoint(endpoint)
+        self.host = self.endpoint.geturl()
+        self._headers = {
+            "Content-Type": "application/json",
+            "User-Agent": "{{cookiecutter.package_name}}py-cli/%s" % {{cookiecutter.package_name}}.__version__,
+        }
+
+        if "{{cookiecutter.varEnvPrefix}}_CA_BUNDLES" in os.environ:
+            requests_verify = os.environ["{{cookiecutter.varEnvPrefix}}_CA_BUNDLES"]
+        if requests_verify is None:
+            requests_verify = True
+        self.verify = requests_verify
+
+    def _url(self, path):
+        return self.endpoint.geturl() + path
+
+    def _configure_endpoint(self, endpoint):
+        return urlparse(endpoint)
+
+    @property
+    def headers(self):
+        token = None
+        headers = {}
+        headers.update(self._headers)
+        if token is not None:
+            headers["Authorization"] = token
+        return headers
+
+    def version(self):
+        path = "/version"
+        resp = requests.get(self._url(path), headers=self.headers, verify=self.verify)
+        resp.raise_for_status()
+        return resp.json()

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/commands/cli.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/commands/cli.py
@@ -1,0 +1,55 @@
+import argparse
+import os
+
+from {{cookiecutter.package_name}}.commands.runserver import RunServerCmd
+from {{cookiecutter.package_name}}.commands.version import VersionCmd
+from {{cookiecutter.package_name}}.commands.openapi import OpenapiCmd
+
+
+def all_commands():
+    return {
+        VersionCmd.name: VersionCmd,
+        RunServerCmd.name: RunServerCmd,
+        OpenapiCmd.name: OpenapiCmd,
+    }
+
+
+def get_parser(commands, parser=None, subparsers=None, env=None):
+    if parser is None:
+        parser = argparse.ArgumentParser()
+
+    if subparsers is None:
+        subparsers = parser.add_subparsers(help="command help")
+
+    for command_class in commands.values():
+        command_class.add_parser(subparsers, env)
+
+    return parser
+
+
+def set_cmd_env(env):
+    """Allow commands to Set environment variables after being called"""
+    if env is not None:
+        for key, value in env.items():
+            os.environ[key] = value
+
+
+def cli():
+    try:
+        parser = get_parser(all_commands())
+        unknown = None
+        args, unknown = parser.parse_known_args()
+        if len(list(vars(args))) == 0:
+            parser.print_help()
+            return
+        set_cmd_env(args.env)
+        if args.parse_unknown:
+            args.func(args, unknown)
+        else:
+            args = parser.parse_args()
+            args.func(args)
+
+    except (argparse.ArgumentTypeError, argparse.ArgumentError) as exc:
+        if os.getenv("{{cookiecutter.varEnvPrefix}}_DEBUG", "false") == "true":
+            raise
+        parser.error(exc.message)

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/commands/command_base.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/commands/command_base.py
@@ -1,0 +1,149 @@
+import argparse
+import json
+import sys
+import subprocess
+import requests
+
+import yaml
+
+from {{cookiecutter.package_name}}.client import {{cookiecutter.baseclass}}Client
+from {{cookiecutter.package_name}}.commands.utils import ServerHost
+
+
+class CommandBase:
+    name = "command-base"
+    help_message = "describe the command"
+    server_client = {{cookiecutter.baseclass}}Client
+    default_media_type = "-"
+    parse_unknown = False
+    output_default = "text"
+
+    def __init__(self, args_options, unknown=None):
+        self.unknown = unknown
+        self.args_options = args_options
+        self.output = args_options.output
+
+    def render(self):
+        if self.output == "none":
+            return
+        if self.output == "json":
+            self._render_json()
+        if self.output == "yaml":
+            self._render_yaml()
+        print(self._render_console())
+
+    def render_error(self, payload):
+        if self.output == "json":
+            self._render_json(payload)
+        elif self.output == "yaml":
+            self._render_yaml(payload)
+        else:
+            raise argparse.ArgumentTypeError(
+                "\n"
+                + yaml.safe_dump(payload, default_flow_style=False, width=float("inf"))
+            )
+
+    @classmethod
+    def call(cls, options, unknown=None, render=True):
+        # @TODO(ant31): all methods should have the 'unknown' parameter
+        if cls.parse_unknown:
+            obj = cls(options, unknown)
+        else:
+            obj = cls(options)
+        obj.exec_cmd(render=render)
+
+    def exec_cmd(self, render=True):
+        try:
+            self._call()
+        except requests.exceptions.RequestException as exc:
+            payload = {"message": str(exc)}
+            if exc.response is not None:
+                content = None
+                try:
+                    content = exc.response.json()
+                except ValueError:
+                    content = exc.response.content
+                payload["response"] = content
+            self.render_error(payload)
+            sys.exit(2)
+        except subprocess.CalledProcessError as exc:
+            payload = {"message": str(exc.output)}
+            self.render_error(payload)
+            sys.exit(exc.returncode)
+
+        if render:
+            self.render()
+
+    @classmethod
+    def add_parser(cls, subparsers, env=None):
+        parser = subparsers.add_parser(cls.name, help=cls.help_message)
+        cls._add_output_option(parser)
+        cls._add_arguments(parser)
+        parser.set_defaults(
+            func=cls.call, env=env, which_cmd=cls.name, parse_unknown=cls.parse_unknown
+        )
+
+    def _render_json(self, value=None):
+        if not value:
+            value = self._render_dict()
+        print(json.dumps(value, indent=2, separators=(",", ": ")))
+
+    def _render_dict(self):
+        raise NotImplementedError
+
+    def _render_console(self):
+        raise NotImplementedError
+
+    def _render_yaml(self, value=None):
+        if not value:
+            value = self._render_dict()
+        print(yaml.safe_dump(value, default_flow_style=False, width=float("inf")))
+
+    def _call(self):
+        raise NotImplementedError
+
+    @classmethod
+    def _add_arguments(cls, parser):
+        raise NotImplementedError
+
+    @classmethod
+    def _add_output_option(cls, parser):
+        parser.add_argument(
+            "--output",
+            default=cls.output_default,
+            choices=["text", "none", "json", "yaml"],
+            help="output format",
+        )
+
+    @classmethod
+    def _add_serverhost_arg(cls, parser):
+        parser.add_argument(
+            "server_host", nargs=1, action=ServerHost, help="server API url"
+        )
+        parser.add_argument(
+            "-k",
+            "--insecure",
+            action="store_true",
+            default=False,
+            help="turn off verification of the https certificate",
+        )
+        parser.add_argument(
+            "--cacert",
+            nargs="?",
+            default=None,
+            help="CA certificate to verify peer against (SSL)",
+        )
+
+    @classmethod
+    def _add_serverhost_option(cls, parser):
+        parser.add_argument("-H", "--host", default=None, help=argparse.SUPPRESS)
+        parser.add_argument(
+            "-k",
+            "--insecure",
+            action="store_true",
+            default=False,
+            help="turn off verification of the https certificate",
+        )
+        parser.add_argument(
+            "--cacert", default=None, help="CA certificate to verify peer against (SSL)"
+        )

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/commands/openapi.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/commands/openapi.py
@@ -1,0 +1,25 @@
+from {{cookiecutter.package_name}}.openapi import openapi
+from {{cookiecutter.package_name}}.commands.command_base import CommandBase
+
+
+class OpenapiCmd(CommandBase):
+    name = "openapi"
+    help_message = "show openapis"
+    output_default = "yaml"
+
+    def __init__(self, options):
+        super().__init__(options)
+        self.openapi = None
+
+    @classmethod
+    def _add_arguments(cls, parser):
+        pass
+
+    def _call(self):
+        self.openapi = openapi()
+
+    def _render_dict(self):
+        return self.openapi
+
+    def _render_console(self):
+        return self.openapi

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/commands/runserver.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/commands/runserver.py
@@ -1,0 +1,34 @@
+import uvicorn
+from {{cookiecutter.package_name}}.main import app
+from {{cookiecutter.package_name}}.commands.command_base import CommandBase
+
+
+class RunServerCmd(CommandBase):
+    name = "run-server"
+    help_message = "Run the registry server (with gunicorn)"
+    parse_unknown = False
+
+    def __init__(self, options, unknown=None):
+        super().__init__(options)
+        self.options = options
+        self.status = {}
+
+    def _call(self):
+        uvicorn.run(
+            app, host=self.options.bind, port=self.options.port, log_level="debug"
+        )
+
+    @classmethod
+    def _add_arguments(cls, parser):
+        parser.add_argument(
+            "-p", "--port", nargs="?", default=8000, type=int, help="server port listen"
+        )
+        parser.add_argument(
+            "-b", "--bind", nargs="?", default="0.0.0.0", help="server bind address"
+        )
+
+    def _render_dict(self):
+        return self.status
+
+    def _render_console(self):
+        return self.status["result"]

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/commands/utils.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/commands/utils.py
@@ -1,0 +1,56 @@
+import argparse
+import json
+import re
+import copy
+import os
+import yaml
+
+
+def ensure_value(namespace, name, value):
+    if getattr(namespace, name, None) is None:
+        setattr(namespace, name, value)
+    return getattr(namespace, name)
+
+
+class ServerHost(argparse.Action):
+    def __call__(self, parser, namespace, value, option_string=None):
+        setattr(namespace, self.dest, value[0])
+
+
+class LoadVariables(argparse.Action):
+    def _parse_cmd(self, var):
+        res = {}
+        try:
+            return json.loads(var)
+        except json.JSONDecodeError as exc:
+            for cvar in var.split(","):
+                split_var = re.match("(.+?)=(.+)", cvar)
+                if split_var is None:
+                    raise ValueError("Malformed variable: %s" % cvar) from exc
+                key, value = split_var.group(1), split_var.group(2)
+                res[key] = value
+        return res
+
+    def _load_from_file(self, filename, ext):
+        with open(filename, "r", encoding="utf-8") as ofile:
+            if ext in [".yml", ".yaml"]:
+                return yaml.load(ofile.read())
+            if ext == ".json":
+                return json.loads(ofile.read())
+            raise ValueError(
+                "File extension is not in [yaml, json, jsonnet]: %s" % filename
+            )
+
+    def load_variables(self, var):
+        _, ext = os.path.splitext(var)
+        if ext not in [".yaml", ".yml", ".json"]:
+            return self._parse_cmd(var)
+        return self._load_from_file(var, ext)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        items = copy.copy(ensure_value(namespace, self.dest, {}))
+        try:
+            items.update(self.load_variables(values))
+        except ValueError as exc:
+            raise parser.error(option_string + ": " + str(exc))
+        setattr(namespace, self.dest, items)

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/commands/version.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/commands/version.py
@@ -1,0 +1,56 @@
+import requests
+
+import {{cookiecutter.package_name}}
+from {{cookiecutter.package_name}}.commands.command_base import CommandBase
+
+
+class VersionCmd(CommandBase):
+    name = "version"
+    help_message = "show versions"
+
+    def __init__(self, options):
+        super().__init__(options)
+        self.api_version = None
+        self.client_version = None
+        self.server_host = options.server_host
+        self.ssl_verify = options.cacert or not options.insecure
+
+    @classmethod
+    def _add_arguments(cls, parser):
+        cls._add_serverhost_arg(parser)
+
+    def _api_version(self):
+        api_version = None
+        try:
+            client = self.server_client(
+                self.server_host, requests_verify=self.ssl_verify
+            )
+            api_version = client.version()
+        except requests.exceptions.RequestException:
+            api_version = ".. Connection error"
+        return api_version
+
+    def _cli_version(self):
+        return {{cookiecutter.package_name}}.__version__
+
+    def _version(self):
+        return {
+            "api-version": self._api_version(),
+            "client-version": self._cli_version(),
+        }
+
+    def _call(self):
+        version = self._version()
+        self.api_version = version["api-version"]
+        self.client_version = version["client-version"]
+
+    def _render_dict(self):
+        return {"api-version": self.api_version, "client-version": self.client_version}
+
+    def _render_console(self):
+        return "\n".join(
+            [
+                "Api-version: %s" % self.api_version,
+                "Client-version: %s" % self.client_version,
+            ]
+        )

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/config.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/config.py
@@ -49,7 +49,7 @@ def getenv(name, default=None, convert=str):
 
 
 def envbool(value: str):
-    return value and (value.lower() in ("1", "true"))
+    return value and (value.lower() in ("1", "true", "True", "yes"))
 
 
 APP_ENVIRON = getenv("APP_ENV", "development")
@@ -69,6 +69,7 @@ APP_ENVIRON = getenv("APP_ENV", "development")
 {{cookiecutter.varEnvPrefix}}_TMP_DIR = os.getenv("{{cookiecutter.varEnvPrefix}}_TMP_DIR", "/tmp/{{cookiecutter.package_name}}")
 {{cookiecutter.varEnvPrefix}}_SENTRY_URL = os.getenv("{{cookiecutter.varEnvPrefix}}_SENTRY_URL", None)
 {{cookiecutter.varEnvPrefix}}_SENTRY_ENV = os.getenv("{{cookiecutter.varEnvPrefix}}_SENTRY_ENV", "development")
+{{cookiecutter.varEnvPrefix}}_DEBUG = getenv("{{cookiecutter.varEnvPrefix}}_DEBUG", False, envbool)
 
 PROMETHEUS_MULTIPROC_DIR = os.getenv(
     "PROMETHEUS_MULTIPROC_DIR", os.path.join({{cookiecutter.varEnvPrefix}}_TMP_DIR, "prometheus")
@@ -84,7 +85,7 @@ class {{cookiecutter.baseclass}}Config:
     def __init__(self, defaults=None, confpath=None):
         self.settings = {
             "{{cookiecutter.package_name}}": {
-                "debug": False,
+                "debug": {{cookiecutter.varEnvPrefix}}_DEBUG,
                 "env": APP_ENVIRON,
                 "url": {{cookiecutter.varEnvPrefix}}_API,
                 "download_dir": {{cookiecutter.varEnvPrefix}}_DOWNLOAD_DIR,

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/openapi.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/openapi.py
@@ -1,26 +1,5 @@
-import json
-
-from fastapi import FastAPI
-
-from {{cookiecutter.package_name}}.api import {{cookiecutter.package_name}} as api
-
-
-def _set_attrs(app, appapi):
-    for attr in [
-        "title",
-        "description",
-        "version",
-        "terms_of_service",
-        "license_info",
-        "servers",
-    ]:
-        value = getattr(appapi, attr, None)
-        if value is not None:
-            setattr(app, attr, value)
+from {{cookiecutter.package_name}}.main import app
 
 
 def openapi():
-    app = FastAPI()
-    _set_attrs(app, api)
-    app.include_router(api.router)
-    print(json.dumps(app.openapi()))
+    return app.openapi()


### PR DESCRIPTION
The base cli uses the std argparse. 

Commands are defined in the separated modules but share or can share a large set of common behaviors. 

Defining a new command should implement the class "CommandBase"
example: [{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/commands/openapi.py 
](https://github.com/connylabs/python-prj-template/compare/add-cli?expand=1#diff-fb1c4ef2d05960a1358aa4dd88e8add8da64b56a60b20b93cc07132999dbd7d7R5)

Overall it's opinionated and this part could be made optional if anyone prefers to use other libraries (e.g click). 
I'm not sure how to make this part of the configuration modular. 


Current commands:
```shell
usage: $app [-h] {version,run-server,openapi} ...

positional arguments:
  {version,run-server,openapi}
                        command help
    version             show versions
    run-server          Run the API server (with uvicorn)
    openapi             show openapis schema

optional arguments:
  -h, --help            show this help message and exit
```

